### PR TITLE
Added optimistic concurrency

### DIFF
--- a/ConsistencyClass.Tests/DatabaseTest.cs
+++ b/ConsistencyClass.Tests/DatabaseTest.cs
@@ -1,0 +1,195 @@
+using System.Collections.Concurrent;
+
+namespace ConsistencyClass.Tests;
+
+public class DatabaseTest
+{
+    [Fact]
+    public void FindForNonExistingRecordReturnsEmpty()
+    {
+        var collection = Database.Collection<DummyVersionedEntity>();
+        var id = Guid.NewGuid().ToString();
+
+        var result = collection.Find(id);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void FindForExistingRecordReturnsEntity()
+    {
+        var collection = Database.Collection<DummyVersionedEntity>();
+        var id = Guid.NewGuid().ToString();
+        var entity = new DummyVersionedEntity(id, 0);
+        collection.Save(id, entity);
+
+        var result = collection.Find(id);
+
+        Assert.NotNull(result);
+        Assert.Equal(id, result?.Id);
+    }
+
+    [Fact]
+    public void SaveBumpsVersionForVersionedEntity()
+    {
+        var collection = Database.Collection<DummyVersionedEntity>();
+        var id = Guid.NewGuid().ToString();
+        var entity = new DummyVersionedEntity(id, 0);
+
+        var result = collection.Save(id, entity);
+
+        Assert.Equal(Result.Success, result);
+        Assert.Equal(1, entity.Version);
+    }
+
+    [Fact]
+    public void SaveStoresNonVersionedEntity()
+    {
+        var collection = Database.Collection<DummyEntity>();
+        var id = Guid.NewGuid().ToString();
+        var entity = new DummyEntity(id);
+
+        var result = collection.Save(id, entity);
+
+        Assert.Equal(Result.Success, result);
+        Assert.Equal(id, entity.Id);
+    }
+
+    [Fact]
+    public void SaveBumpsVersionInDatabaseForVersionedEntity()
+    {
+        var collection = Database.Collection<DummyVersionedEntity>();
+        var id = Guid.NewGuid().ToString();
+        var entity = new DummyVersionedEntity(id, 0);
+
+        collection.Save(id, entity);
+
+        var entityFromDb = collection.Find(id);
+        Assert.NotNull(entityFromDb);
+        Assert.Equal(1, entityFromDb?.Version);
+    }
+
+    [Fact]
+    public void SaveVersionedEntityCanBeRunMultipleTimesSequentially()
+    {
+        var collection = Database.Collection<DummyVersionedEntity>();
+        var id = Guid.NewGuid().ToString();
+        var currentVersion = 0;
+        var entity = new DummyVersionedEntity(id, currentVersion);
+
+        do
+        {
+            var result = collection.Save(id, entity);
+
+            Assert.Equal(Result.Success, result);
+            Assert.Equal(++currentVersion, entity.Version);
+        } while (currentVersion < 5);
+    }
+
+    [Fact]
+    public void SaveEntityCanBeRunMultipleTimesSequentiallyWithBumpedVersion()
+    {
+        var collection = Database.Collection<DummyEntity>();
+        var id = Guid.NewGuid().ToString();
+        var currentVersion = 0;
+        var entity = new DummyEntity(id);
+
+        do
+        {
+            var result = collection.Save(id, entity, currentVersion++);
+
+            Assert.Equal(Result.Success, result);
+        } while (currentVersion < 5);
+    }
+
+    [Fact]
+    public void SaveVersionedEntityCanBeRunMultipleTimesSequentiallyWithBumpedVersion()
+    {
+        var collection = Database.Collection<DummyVersionedEntity>();
+        var id = Guid.NewGuid().ToString();
+        var currentVersion = 0;
+        var entity = new DummyVersionedEntity(id, currentVersion);
+
+        do
+        {
+            var result = collection.Save(id, entity, currentVersion);
+
+            Assert.Equal(Result.Success, result);
+            Assert.Equal(++currentVersion, entity.Version);
+        } while (currentVersion < 5);
+    }
+
+    [Fact]
+    public void SaveVersionedEntitySucceedsWhenExplicitExpectedVersionMatches()
+    {
+        var collection = Database.Collection<DummyVersionedEntity>();
+        var id = Guid.NewGuid().ToString();
+        var entity = new DummyVersionedEntity(id, 0);
+
+        collection.Save(id, entity, 0);
+
+        var result = collection.Save(id, entity, 1);
+
+        Assert.Equal(Result.Success, result);
+        Assert.Equal(2, entity.Version);
+    }
+
+    [Fact]
+    public void SaveEntitySucceedsWhenExplicitExpectedVersionMatches()
+    {
+        var collection = Database.Collection<DummyEntity>();
+        var id = Guid.NewGuid().ToString();
+        var entity = new DummyEntity(id);
+
+        collection.Save(id, entity, 0);
+
+        var result = collection.Save(id, entity, 1);
+
+        Assert.Equal(Result.Success, result);
+    }
+
+    [Fact]
+    public void SaveFailsWhenExplicitExpectedVersionDoesNotMatch()
+    {
+        var collection = Database.Collection<DummyVersionedEntity>();
+        var id = Guid.NewGuid().ToString();
+        var entity = new DummyVersionedEntity(id, 0);
+        var oldEntity = new DummyVersionedEntity(id, 0);
+
+        collection.Save(id, entity);
+
+        var result = collection.Save(id, oldEntity);
+
+        Assert.Equal(Result.Failure, result);
+        Assert.Equal(1, entity.Version);
+    }
+
+    [Fact]
+    public async Task CantUpdateConcurrently()
+    {
+        var collection = Database.Collection<DummyVersionedEntity>();
+        var id = Guid.NewGuid().ToString();
+
+        var results = new ConcurrentBag<Result>();
+        var tasks = Enumerable.Range(0, 1000).Select(_ => Task.Run(() =>
+        {
+            var entity = collection.Find(id) ?? new DummyVersionedEntity(id, 0);
+            results.Add(collection.Save(id, entity));
+        }));
+
+        await Task.WhenAll(tasks);
+
+        Assert.Contains(Result.Failure, results);
+        Assert.True((collection.Find(id)?.Version ?? 0) < 1000);
+    }
+}
+
+public record DummyEntity(string Id);
+
+public class DummyVersionedEntity(string id, int version): IVersionedWithAutoIncrement
+{
+    public string Id { get; } = id;
+    public int Version { get; private set; } = version;
+
+    public void SetVersion(int version) => Version = version;
+}

--- a/ConsistencyClass.Tests/WithdrawingTest.cs
+++ b/ConsistencyClass.Tests/WithdrawingTest.cs
@@ -164,7 +164,7 @@ public class WithdrawingTest
     private CardId NewCreditCard()
     {
         var virtualCreditCard = VirtualCreditCard.Create(CardId.Random());
-        creditCardDatabase.Save(virtualCreditCard);
+        creditCardDatabase.Save(virtualCreditCard, 0);
         return virtualCreditCard.Id;
     }
 

--- a/ConsistencyClass/AddLimitService.cs
+++ b/ConsistencyClass/AddLimitService.cs
@@ -5,9 +5,12 @@ internal class AddLimitService(VirtualCreditCardDatabase virtualCreditCardDataba
     public Result AddLimit(CardId cardId, Money limit)
     {
         var card = virtualCreditCardDatabase.Find(cardId);
+        var expectedVersion = card.Version;
+
         var result = card.AssignLimit(limit);
-        virtualCreditCardDatabase.Save(card);
-        return result;
+
+        return result == Result.Success
+            ? virtualCreditCardDatabase.Save(card, expectedVersion)
+            : result;
     }
 }
-

--- a/ConsistencyClass/CloseCycleService.cs
+++ b/ConsistencyClass/CloseCycleService.cs
@@ -5,8 +5,12 @@ internal class CloseCycleService(VirtualCreditCardDatabase virtualCreditCardData
     public Result Close(CardId cardId)
     {
         var card = virtualCreditCardDatabase.Find(cardId);
+        var expectedVersion = card.Version;
+
         var result = card.CloseCycle();
-        virtualCreditCardDatabase.Save(card);
-        return result;
+
+        return result == Result.Success
+            ? virtualCreditCardDatabase.Save(card, expectedVersion)
+            : result;
     }
 }

--- a/ConsistencyClass/Database.cs
+++ b/ConsistencyClass/Database.cs
@@ -1,0 +1,94 @@
+namespace ConsistencyClass;
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+
+interface IVersioned
+{
+    public int Version { get; }
+}
+
+interface IVersionedWithAutoIncrement : IVersioned
+{
+    public void SetVersion(int version);
+}
+
+public record RecordWithVersion(object? Record, int Version)
+{
+    public static readonly RecordWithVersion NoRecord = new(null, 0);
+}
+
+public class Database
+{
+    public static DatabaseCollection<T> Collection<T>() => new();
+}
+
+public class DatabaseCollection<T>
+{
+    private readonly ConcurrentDictionary<string, RecordWithVersion> entries = new();
+
+    public Result Save(string id, T record)
+    {
+        var expectedVersion = record is IVersioned versioned
+            ? versioned.Version
+            : entries.GetValueOrDefault(id, RecordWithVersion.NoRecord).Version;
+
+        return Save(id, record, expectedVersion);
+    }
+
+    public Result Save(string id, T record, int expectedVersion)
+    {
+        var newExpectedVersion = expectedVersion + 1;
+        var wasUpdated = false;
+
+        entries.AddOrUpdate(
+            id,
+            _ =>
+            {
+                if (expectedVersion != RecordWithVersion.NoRecord.Version)
+                    return RecordWithVersion.NoRecord;
+
+                if (record is IVersionedWithAutoIncrement versioned)
+                    versioned.SetVersion(newExpectedVersion);
+
+                wasUpdated = true;
+                return new RecordWithVersion(record, newExpectedVersion);
+            },
+            (_, currentValue) =>
+            {
+                var currentVersion = currentValue.Version;
+
+                if (currentVersion != expectedVersion){
+                    // Version conflict, don't update the value
+                    return currentValue;  // Keep the currentValue in the map
+                }
+
+                if (record is IVersionedWithAutoIncrement versioned)
+                    versioned.SetVersion(newExpectedVersion);
+
+                wasUpdated = true;
+                return new RecordWithVersion(record, newExpectedVersion);
+            });
+
+        return wasUpdated ? Result.Success : Result.Failure;
+    }
+
+    public T? Find(string id)
+    {
+        return entries.TryGetValue(id, out var recordWithVersion)
+            ? (T?)recordWithVersion.Record
+            : default;
+    }
+
+    public Result Handle(string id, Func<T?, T> handle, Func<T> getDefault)
+    {
+        var entry = entries.GetValueOrDefault(id, RecordWithVersion.NoRecord);
+
+        var result = handle(entry.Record != null
+            ? (T)entry.Record
+            : getDefault());
+
+        return Save(id, result, entry.Version);
+    }
+}

--- a/ConsistencyClass/EventStore.cs
+++ b/ConsistencyClass/EventStore.cs
@@ -1,0 +1,77 @@
+namespace ConsistencyClass;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+internal class EventStore
+{
+    private readonly DatabaseCollection<EventStream> streams = Database.Collection<EventStream>();
+
+    public List<T> ReadEvents<T>(string streamId) =>
+        ExistingEventStreamOrEmpty(streamId)
+            .EventsOfType<T>();
+
+    public Result AppendToStream<T>(string streamId, List<T> events, int expectedVersion) where T: notnull
+    {
+        var version = expectedVersion;
+
+        var stream = ExistingEventStreamOrEmpty(streamId);
+
+        var newEvents = events.Select(e =>
+            EventEnvelope.From(streamId, e, ++version)
+        ).ToList();
+
+        return streams.Save(streamId, stream.Append(newEvents), expectedVersion);
+    }
+
+    private EventStream ExistingEventStreamOrEmpty(string streamId) =>
+        streams.Find(streamId) ?? EventStream.Empty(streamId);
+}
+
+internal record EventStream(string Id, List<EventEnvelope> Events)
+{
+    public static EventStream Empty(string id) => new(id, new List<EventEnvelope>());
+
+    public EventStream Append(List<EventEnvelope> events) =>
+        new(Id, Events.Concat(events).ToList());
+
+    public List<T> EventsOfType<T>() =>
+        Events
+            .Select(e => e.Data)
+            .OfType<T>()
+            .ToList();
+}
+
+
+internal record EventMetadata(
+    string StreamId,
+    string EventType,
+    Guid EventId,
+    int Version,
+    DateTime OccurredAt
+)
+{
+    public static EventMetadata From(Type eventType, string streamId, int version) =>
+        new(
+            streamId,
+            eventType.FullName ?? eventType.Name,
+            Guid.NewGuid(),
+            version,
+            DateTime.UtcNow
+        );
+}
+
+internal record EventEnvelope(
+    object Data,
+    EventMetadata Metadata)
+{
+    public static EventEnvelope From(string streamId, object eventObj, int version)
+    {
+        return new EventEnvelope(
+            eventObj,
+            EventMetadata.From(eventObj.GetType(), streamId, version)
+        );
+    }
+}
+

--- a/ConsistencyClass/OwnershipService.cs
+++ b/ConsistencyClass/OwnershipService.cs
@@ -5,26 +5,25 @@ internal class OwnershipService(OwnershipDatabase ownershipDatabase)
     public Result AddAccess(CardId cardId, OwnerId ownerId)
     {
         var ownership = ownershipDatabase.Find(cardId);
+        var expectedVersion = ownership.Version;
 
         if (ownership.Size >= 2)
         {
             return Result.Failure;
         }
 
-        var updatedOwnership = ownership.AddAccess(ownerId);
-        ownershipDatabase.Save(cardId, updatedOwnership);
+        ownership = ownership.AddAccess(ownerId);
 
-        return Result.Success;
+        return ownershipDatabase.Save(cardId, ownership, expectedVersion);
     }
 
     public Result RevokeAccess(CardId cardId, OwnerId ownerId)
     {
         var ownership = ownershipDatabase.Find(cardId);
-        var updatedOwnership = ownership.Revoke(ownerId);
+        var expectedVersion = ownership.Version;
 
-        ownershipDatabase.Save(cardId, updatedOwnership);
+        ownership = ownership.Revoke(ownerId);
 
-        return Result.Success;
+        return ownershipDatabase.Save(cardId, ownership, expectedVersion);
     }
 }
-

--- a/ConsistencyClass/RepayService.cs
+++ b/ConsistencyClass/RepayService.cs
@@ -5,8 +5,12 @@ class RepayService(VirtualCreditCardDatabase virtualCreditCardDatabase)
     public Result Repay(CardId cardId, Money amount)
     {
         var card = virtualCreditCardDatabase.Find(cardId);
+        var expectedVersion = card.Version;
+
         var result = card.Repay(amount);
-        virtualCreditCardDatabase.Save(card);
-        return result;
+
+        return result == Result.Success
+            ? virtualCreditCardDatabase.Save(card, expectedVersion)
+            : result;
     }
 }

--- a/ConsistencyClass/VirtualCreditCardDatabase.cs
+++ b/ConsistencyClass/VirtualCreditCardDatabase.cs
@@ -4,81 +4,36 @@ namespace ConsistencyClass;
 
 internal class VirtualCreditCardDatabase
 {
-    private readonly ConcurrentDictionary<CardId, List<EventEnvelope>> cards = new();
+    private readonly EventStore eventStore = new EventStore();
 
-    public void Save(VirtualCreditCard card)
+    public Result Save(VirtualCreditCard card, int expectedVersion)
     {
-        if (!cards.TryGetValue(card.Id, out var stream))
-        {
-            stream = new List<EventEnvelope>();
-            cards[card.Id] = stream;
-        }
+        var streamId = card.Id.Id.ToString();
 
-        var version = stream.Count;
-
-        var newEvents = card.DequeuePendingEvents()
-            .Select(e => EventEnvelope.From(card.Id.Id.ToString(), e, ++version))
-            .ToList();
-
-        stream.AddRange(newEvents);
+        return eventStore.AppendToStream(
+            streamId,
+            card.DequeuePendingEvents(),
+            expectedVersion
+        );
     }
 
     public VirtualCreditCard Find(CardId cardId)
     {
-        if (!cards.TryGetValue(cardId, out var stream))
-            throw new InvalidOperationException($"Could not find card with id {cardId}");
+        var streamId = cardId.Id.ToString();
 
-        var events = stream
-            .Select(envelope => envelope.Data)
-            .OfType<VirtualCreditCardEvent>()
-            .ToList();
+        var events = eventStore.ReadEvents<VirtualCreditCardEvent>(streamId);
 
         return VirtualCreditCard.Recreate(events);
     }
 }
 
-internal record EventMetadata(
-    string StreamId,
-    string EventType,
-    Guid EventId,
-    int Version,
-    DateTime OccurredAt
-)
-{
-    public static EventMetadata From(Type eventType, string streamId, int version) =>
-        new(
-            streamId,
-            eventType.FullName ?? eventType.Name,
-            Guid.NewGuid(),
-            version,
-            DateTime.UtcNow
-        );
-}
-
-internal record EventEnvelope(
-    object Data,
-    EventMetadata Metadata)
-{
-    public static EventEnvelope From(string streamId, object eventObj, int version)
-    {
-        return new EventEnvelope(
-            eventObj,
-            EventMetadata.From(eventObj.GetType(), streamId, version)
-        );
-    }
-}
-
 internal class OwnershipDatabase
 {
-    private readonly ConcurrentDictionary<CardId, Ownership> _ownerships = new();
+    private readonly DatabaseCollection<Ownership> ownerships = Database.Collection<Ownership>();
 
-    public void Save(CardId cardId, Ownership ownership)
-    {
-        _ownerships[cardId] = ownership;
-    }
+    public Result Save(CardId cardId, Ownership ownership, int expectedVersion) =>
+        ownerships.Save(cardId.Id.ToString(), ownership, expectedVersion);
 
-    public Ownership Find(CardId cardId)
-    {
-        return _ownerships.TryGetValue(cardId, out var ownership) ? ownership : Ownership.Empty();
-    }
+    public Ownership Find(CardId cardId) =>
+        ownerships.Find(cardId.Id.ToString()) ?? Ownership.Empty();
 }

--- a/ConsistencyClass/WithdrawService.cs
+++ b/ConsistencyClass/WithdrawService.cs
@@ -8,9 +8,13 @@ class WithdrawService(VirtualCreditCardDatabase virtualCreditCardDatabase, Owner
             return Result.Failure;
 
         var card = virtualCreditCardDatabase.Find(cardId);
+        var expectedVersion = card.Version;
+
         var result = card.Withdraw(amount);
-        virtualCreditCardDatabase.Save(card);
-        return result;
+
+        return result == Result.Success
+            ? virtualCreditCardDatabase.Save(card, expectedVersion)
+            : result;
     }
 }
 


### PR DESCRIPTION
**1. Added optimistic concurrency handling**
Added explicit expected version usage in the database and event store. Entities can express that they maintain their own versions through `Versioned` interface.

Made both `Ownership` and `VirtualCreditCard` implement it to showcase that Optimistic Concurrency can be handled for both regular and event-sourced entities.

**2. Unified database usage with a simple in-memory database**

It already supports optimistic concurrency and can be used both for a regular database and an event store.

Added the explicit event store implementation to showcase how event stores are built. Internally it's using the same in-memory database as ownership database. That also shows that the event store is "just" a key/value database, where value is a list of events (a.k.a. Event Stream).